### PR TITLE
fix(style): トップページのブログ記事一覧のサイズを調整

### DIFF
--- a/packages/app/nuxt.config.js
+++ b/packages/app/nuxt.config.js
@@ -52,6 +52,7 @@ export default {
   mode: 'universal',
   srcDir: 'src',
   head,
+  modern: 'client',
   css: ['~/assets/scss/global.scss'],
   loading: { color: 'var(--text-color)' },
   pageTransition: {

--- a/packages/app/src/components/molecules/PostCard.vue
+++ b/packages/app/src/components/molecules/PostCard.vue
@@ -58,6 +58,7 @@ export default Vue.extend({
   display: block;
   overflow: hidden;
   text-decoration: none;
+  height: 100%;
   width: 100%;
   transition: all 0.2s ease-out;
 

--- a/packages/app/src/pages/index.vue
+++ b/packages/app/src/pages/index.vue
@@ -120,13 +120,13 @@ export default Vue.extend({
   list-style: none;
   display: grid;
   justify-content: center;
-  grid-template-columns: repeat(auto-fit, minmax(288px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(224px, 1fr));
   grid-gap: 1rem;
 }
 
 .postItem {
   margin: auto;
-  max-width: 320px;
+  height: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
## スクショ

### 更新後
<img width="848" alt="スクリーンショット 2020-06-06 11 15 16" src="https://user-images.githubusercontent.com/8909592/83933854-3f546180-a7e7-11ea-9355-0ceee0daa251.png">

### 更新前
<img width="834" alt="スクリーンショット 2020-06-06 11 16 09" src="https://user-images.githubusercontent.com/8909592/83933850-38c5ea00-a7e7-11ea-9e8c-874aad9457f3.png">
